### PR TITLE
Enable tap to close in the input dialog

### DIFF
--- a/dialogs.lua
+++ b/dialogs.lua
@@ -83,6 +83,7 @@ local function showChatGPTDialog(ui, highlightedText, message_history)
   buttons = {
     {
       text = _("Cancel"),
+      id = "close",
       callback = function()
         UIManager:close(input_dialog)
       end


### PR DESCRIPTION
Besides clicking "Cancel" button, tapping area off InputDialog window also closes this dialog.

Refer InputDialog:onCloseDialog() and InputDialog:onTap() for details.