### PR TITLE
feat: add support for user-defined custom prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ local CONFIGURATION = {
 }
 ```
 
+### Custom Prompts
+
+You can add predefined prompts for specific tasks in the `configuration.lua` file. This allows you to customize the type of inquiries you can make based on your usual needs.
+
+```lua
+local CONFIGURATION = {
+    api_key = "YOUR_API_KEY",
+    model = "gpt-4o-mini",
+    base_url = "https://api.openai.com/v1/chat/completions",
+    prompts = {
+        { name = "Summarize Text", prompt = "Please summarize the following text." },
+        { name = "ELI5", prompt = "Explain like I'm five: "},
+        { name = "Find Key Points", prompt = "List the key points in the following content." }
+    }
+}
+```
+
 ## Installation
 
 If you clone this project, you should be able to put the directory, `askgpt.koplugin`, in the `koreader/plugins` directory and it should work. If you want to use the plugin without cloning the project, you can download the zip file from the releases page and extract the `askgpt.koplugin` directory to the `koreader/plugins` directory. If for some reason you extract the files of this repository in another directory, rename it before moving it to the `koreader/plugins` directory.

--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -3,6 +3,20 @@ local CONFIGURATION = {
     model = "gpt-4o-mini",
     base_url = "https://api.openai.com/v1/chat/completions",
     additional_parameters = {},
+    prompts = {
+        {
+            name = "Summarize Text",
+            prompt = "Summarize the following text"
+        },
+        {
+            name = "ELI5",
+            prompt = "Explain the following as if I'm a five-year-old"
+        },
+        {
+            name = "Find Key Points",
+            prompt = "List the key points from the following text"
+        }
+    }
 }
 
 return CONFIGURATION


### PR DESCRIPTION
This PR:
- added support for user-defined custom prompts within configuration.lua
- updated `README.md` and `configuration.lua.sample` to include detailed instructions on setting up and using custom prompts.