### PR TITLE
feat: Summarize text and edit translation prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ local CONFIGURATION = {
 }
 ```
 
+### Summarize 
+To enable summarize, you can set the `summary` parameter in the `features` table. 
+By setting if you have `translate_to` parameter, it will automatically summarize the text then translate to the language you specify.
+
+the default `summary` value is `false`.
+
+```lua
+local CONFIGURATION = {
+    api_key = "YOUR_API_KEY",
+    model = "gpt-4o-mini",
+    base_url = "https://api.openai.com/v1/chat/completions",
+    features = {
+        translate_to = "French",
+        summary = true
+    }
+}
+```
+
 ## Installation
 
 If you clone this project, you should be able to put the directory, `askgpt.koplugin`, in the `koreader/plugins` directory and it should work. If you want to use the plugin without cloning the project, you can download the zip file from the releases page and extract the `askgpt.koplugin` directory to the `koreader/plugins` directory. If for some reason you extract the files of this repository in another directory, rename it before moving it to the `koreader/plugins` directory.

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -40,9 +40,9 @@ local function summaryText(text, target_language)
   local target_language_isNullOrEmpty = isStringEmptyOrNil(target_language)
   local content = ""
   if target_language_isNullOrEmpty then
-    content = "Summarize the following text, highlighting the main points and key takeaways:" .. text
+    content = "Summarize the following text, highlighting the main points and key takeaways: " .. text
   else 
-    content = "Summarize the following text using ".. target_language .." language, highlighting the main points and key takeaways:" .. text
+    content = "Summarize the following text , highlighting the main points and key takeaways then translate to".. target_languange ..": " .. text
   end
   
   local summary_message = {

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -42,7 +42,7 @@ local function summaryText(text, target_language)
   if target_language_isNullOrEmpty then
     content = "Summarize the following text, highlighting the main points and key takeaways: " .. text
   else 
-    content = "Summarize the following text , highlighting the main points and key takeaways then translate to".. target_languange ..": " .. text
+    content = "Summarize the following text , highlighting the main points and key takeaways then translate to".. target_language ..": " .. text
   end
   
   local summary_message = {

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -24,7 +24,7 @@ local function translateText(text, target_language)
   local translation_history = {
     {
       role = "system",
-      content = "You are a helpful translation assistant. Provide direct translations without additional commentary."
+      content = "You are a helpful translation assistant. Provide direct translations without additional commentary. make it clear, understandable, and as natural as possible like native."
     },
     translation_message
   }

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -16,6 +16,10 @@ else
   print("configuration.lua not found, skipping...")
 end
 
+local function isStringEmptyOrNil(str)
+    return str == nil or str == ""
+end
+
 local function translateText(text, target_language)
   local translation_message = {
     role = "user",
@@ -33,12 +37,14 @@ end
 
 
 local function summaryText(text, target_language)
-  target_languange_isNullOrEmpty = isStringEmptyOrNil(target_language)
-  content = ""
+  local target_language_isNullOrEmpty = isStringEmptyOrNil(target_language)
+  local content = ""
   if target_language_isNullOrEmpty then
     content = "Summarize the following text, highlighting the main points and key takeaways:" .. text
   else 
     content = "Summarize the following text using ".. target_language .." language, highlighting the main points and key takeaways:" .. text
+  end
+  
   local summary_message = {
     role = "user",
     content = content

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -40,9 +40,9 @@ local function summaryText(text, target_language)
   local target_language_isNullOrEmpty = isStringEmptyOrNil(target_language)
   local content = ""
   if target_language_isNullOrEmpty then
-    content = "Summarize the following text, highlighting the main points and key takeaways: " .. text
+        content = "Create a concise summary capturing the key points of this text: " .. text
   else 
-    content = "Summarize the following text , highlighting the main points and key takeaways then translate to".. target_language ..": " .. text
+        content = "Create a concise summary in " .. target_language .. " language: " .. text
   end
   
   local summary_message = {
@@ -52,7 +52,7 @@ local function summaryText(text, target_language)
   local summary_history = {
     {
       role = "system",
-      content = "You are a helpful summary assistant. Provide direct summary without commentary. make it clear, understandable, and as natural as possible like native."
+      content = "Create clear and concise summaries focusing on essential information only."
     },
     summary_message
   }
@@ -190,7 +190,7 @@ local function showChatGPTDialog(ui, highlightedText, message_history)
   end
 
 
-  if CONFIGURATION and CONFIGURATION.features and CONFIGURATION.features.summary then
+  if CONFIGURATION and CONFIGURATION.features and (CONFIGURATION.features.summary==true) then
     table.insert(buttons, {
       text = _("Summary"),
       callback = function()

--- a/dialogs.lua
+++ b/dialogs.lua
@@ -52,7 +52,7 @@ local function summaryText(text, target_language)
   local summary_history = {
     {
       role = "system",
-      content = "You are a helpful translation assistant. Provide direct summary without commentary . make it clear, understandable, and as natural as possible like native."
+      content = "You are a helpful summary assistant. Provide direct summary without commentary. make it clear, understandable, and as natural as possible like native."
     },
     summary_message
   }


### PR DESCRIPTION
add summarization features and edit the translation prompt because sometimes the translated text is weird when I read it. 

I love @miaachan in #23  implement it but it takes more step. like click custom prompt button then click desired prompt


note: sorry if the commit message weird and a lot of typos fix.