### PR TITLE
Add custom prompts and change translation behavior + Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,9 @@ return CONFIGURATION
 
 Additionally, as other extra features are rolled out, they will be optional and can be set in the `features` table in the `configuration.lua` file.
 
-
 ### Translation
 
-To enable translation, you can set the `translate_to` parameter in the `features` table. For example, if you want to translate the text to French, you can set the `translate_to` parameter to `"French"`.
-
-By setting the `translate_to` parameter, you can have the plugin translate the text to the language you specify. This is useful if you are reading a book in a language you are not fluent in and want to understand a chunk of text in a language you are more comfortable with.
+To enable translation, simply add a translation prompt to your features.custom_prompts configuration. The prompt should specify the target language and any other translation preferences. For example this one is for French:
 
 ```lua
 local CONFIGURATION = {
@@ -56,10 +53,34 @@ local CONFIGURATION = {
     model = "gpt-4o-mini",
     base_url = "https://api.openai.com/v1/chat/completions",
     features = {
-        translate_to = "French"
+        custom_prompts = {
+            translation = "Please translate the following text to French with definition."
+        }
     }
 }
 ```
+
+### Custom Prompts
+
+You can customize the prompts used for different interactions by adding them to the `features.custom_prompts` section. Each prompt (except 'system') will automatically generate a button in the interface. The button's name will be the capitalized version of the prompt key.
+
+For example, this configuration:
+
+```lua
+local CONFIGURATION = {
+    api_key = "YOUR_API_KEY",
+    model = "gpt-4o-mini",
+    base_url = "https://api.openai.com/v1/chat/completions",
+    features = {
+        custom_prompts = {
+            summarize = "Please summarize the following text.",
+            translate = "Please translate the following text to French."
+        }
+    }
+}
+```
+
+Will generate buttons labeled "Summarize" and "Translate" in the interface.
 
 ## Installation
 

--- a/configuration.lua.sample
+++ b/configuration.lua.sample
@@ -3,6 +3,14 @@ local CONFIGURATION = {
     model = "gpt-4o-mini",
     base_url = "https://api.openai.com/v1/chat/completions",
     additional_parameters = {},
+    features = {
+        custom_prompts = {
+            system = "You are a helpful AI assistant analyzing text from a book. Be concise and insightful in your responses.",
+            translation = "You are a skilled translator and language expert. For each text: 1) Provide an accurate translation to French, 2) Then explain its meaning and context in the original language to help with understanding.",
+            summarize = "Provide a concise summary of the following text, highlighting the key points.",
+            explain = "Explain this text as if teaching it to someone, breaking down complex concepts."
+        }
+    }
 }
 
 return CONFIGURATION

--- a/gpt_query.lua
+++ b/gpt_query.lua
@@ -24,8 +24,16 @@ local ltn12 = require("ltn12")
 local json = require("json")
 
 local function queryChatGPT(message_history)
+  if not message_history or #message_history == 0 then
+    error("No message history provided")
+  end
+
   -- Use api_key from CONFIGURATION or fallback to the api_key module
   local api_key_value = CONFIGURATION and CONFIGURATION.api_key or api_key
+  if not api_key_value then
+    error("No API key configured")
+  end
+
   local api_url = CONFIGURATION and CONFIGURATION.base_url or "https://api.openai.com/v1/chat/completions"
   local model = CONFIGURATION and CONFIGURATION.model or "gpt-4o-mini"
 
@@ -65,11 +73,15 @@ local function queryChatGPT(message_history)
   }
 
   if code ~= 200 then
-    error("Error querying ChatGPT API: " .. code)
+    error("Error querying ChatGPT API: " .. (code or "unknown error"))
   end
 
   local response = json.decode(table.concat(responseBody))
-  return response.choices[1].message.content
+  if not response or not response.choices or not response.choices[1] or not response.choices[1].message then
+    error("Invalid response format from API")
+  end
+
+  return response.choices[1].message.content or "No response content"
 end
 
 return queryChatGPT


### PR DESCRIPTION
Based on ideas from PRs: https://github.com/drewbaumann/AskGPT/pull/23 and https://github.com/drewbaumann/AskGPT/pull/24 :    
1. Add support of custom prompts that will automatically generate buttons in the dialog.
2. Change the translation, so that it is just a prompt.
3. Add more error handling parts.
4. Fix README.md and sample according to the changes.